### PR TITLE
fix: guard TraceResult.HitEntity against null/invalid pointer

### DIFF
--- a/TTT/CS2/Extensions/TraceResultExtensions.cs
+++ b/TTT/CS2/Extensions/TraceResultExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System.Linq.Expressions;
-using CounterStrikeSharp.API;
-using CounterStrikeSharp.API.Core;
-using CounterStrikeSharp.API.Modules.Entities;
-using CounterStrikeSharp.API.Modules.Memory;
+﻿using CounterStrikeSharp.API.Core;
 using RayTraceAPI;
 
 namespace TTT.CS2.Extensions;
@@ -18,13 +14,30 @@ public static class TraceResultExtensions {
     where T : CEntityInstance {
     entity = null;
 
+    // The ray hit nothing, world geometry, or a static prop: HitEntity is a
+    // null/invalid native pointer. Wrapping it and reading a schema field
+    // (DesignerName) dereferences bad memory and hard-crashes the server, so
+    // bail before touching it.
+    if (trace.HitEntity == nint.Zero) return false;
+
     var entityInstance = new CEntityInstance(trace.HitEntity);
+    if (!entityInstance.IsValid) return false;
 
-    if (string.IsNullOrWhiteSpace(entityInstance.DesignerName)) { return false; }
+    var hitName = entityInstance.DesignerName;
+    if (string.IsNullOrWhiteSpace(hitName)) return false;
 
-    var baseEntity = entityInstance.As<CBaseEntity>();
-    
-    entity = baseEntity.As<T>();
+    // Honor the requested name filter (previously designerName/matchType were
+    // ignored, so this returned the first named entity it hit regardless).
+    var matches = matchType switch {
+      DesignerNameMatchType.Equals     => hitName == designerName,
+      DesignerNameMatchType.StartsWith => hitName.StartsWith(designerName),
+      DesignerNameMatchType.EndsWith   => hitName.EndsWith(designerName),
+      DesignerNameMatchType.Contains   => hitName.Contains(designerName),
+      _                                => false
+    };
+    if (!matches) return false;
+
+    entity = entityInstance.As<T>();
     return true;
   }
 }


### PR DESCRIPTION
## Problem

`TryGetHitEntityByDesignerName` wrapped `trace.HitEntity` in a `CEntityInstance` and immediately read `DesignerName` **without validating the pointer**:

```csharp
var entityInstance = new CEntityInstance(trace.HitEntity);
if (string.IsNullOrWhiteSpace(entityInstance.DesignerName)) { return false; }
```

`TraceResult.HitEntity` is a raw native pointer (`nint`), only non-zero when the ray strikes an actual **entity**. When the ray hits world geometry, a static prop, or empty space, `HitEntity` is `nint.Zero`. Reading the `DesignerName` schema field off that pointer dereferences bad memory and **hard-crashes the CS2 server** (a native access violation, not a catchable managed exception).

This is the reported "bad pointer" crash — e.g. pressing **E** to ID a body while aimed slightly off it, and the `NameDisplayer` timer tracing into the world every 0.25s.

## Fix

- Bail when `trace.HitEntity == nint.Zero`, then double-check `CEntityInstance.IsValid` before reading any schema field. (`PropMover.cs` already uses this exact `IsValid` guard pattern.)
- Also **honor `designerName`/`matchType`**, which were previously ignored entirely — the method returned the first named entity it hit regardless of name. Callers like `NameDisplayer` (`<CCSPlayerController>("player")`) and `Tripwire` rely on that filter; without it they read `PlayerName` off arbitrary hit entities.
- Drop the unused `using`s and the redundant `As<CBaseEntity>()` intermediate cast.

## Verification

`dotnet build TTT/CS2/CS2.csproj` (net10.0) succeeds with 0 errors and no new warnings in this file. **Not yet tested on a live server** — worth a smoke test that body ID / name display still trigger on a real player pawn, since the name filter is now actually enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)