### PR TITLE
fix: resolve controller from hit pawn (garbled name / tripwire FF check)

### DIFF
--- a/TTT/CS2/GameHandlers/NameDisplayer.cs
+++ b/TTT/CS2/GameHandlers/NameDisplayer.cs
@@ -26,14 +26,18 @@ public class NameDisplayer : IPluginModule {
         InteractsExclude = (ulong)InteractionLayers.NoDraw
       });
 
-      if (!result.TryGetHitEntityByDesignerName<CCSPlayerController>(
-        "player",
-        out var hitPlayer))
-        return;
-      
-      if (hitPlayer == null) return;
-      
-      player.PrintToCenterAlert($"{hitPlayer.PlayerName}");
+      // The ray hits the player PAWN, not the controller. Reading PlayerName
+      // off the pawn pointer yields garbage (a stray glyph), so resolve the
+      // controller from the pawn first. Use continue, not return, so every
+      // player is processed (return bailed the whole loop on the first miss).
+      if (!result.TryGetHitEntityByDesignerName<CCSPlayerPawn>("player",
+        out var pawn) || pawn == null)
+        continue;
+
+      var hitPlayer = pawn.Controller.Value?.As<CCSPlayerController>();
+      if (hitPlayer == null || !hitPlayer.IsValid) continue;
+
+      player.PrintToCenterAlert(hitPlayer.PlayerName);
     }
   }
 }

--- a/TTT/CS2/Items/Tripwire/TripwireMovementListener.cs
+++ b/TTT/CS2/Items/Tripwire/TripwireMovementListener.cs
@@ -72,13 +72,17 @@ public class TripwireMovementListener(IServiceProvider provider)
           InteractsExclude = (ulong)InteractionLayers.NoDraw
         }, out var result);
 
+      // The ray hits the player PAWN; resolve the controller from it before
+      // looking up the player (SteamID/Index read off the pawn are garbage).
       if (!result.DidHit
-        || !result.TryGetHitEntityByDesignerName<CCSPlayerController>("player",
-          out var player))
+        || !result.TryGetHitEntityByDesignerName<CCSPlayerPawn>("player",
+          out var pawn) || pawn == null)
         continue;
 
-      if (!config.FriendlyFireTriggers && player != null) {
-        var apiPlayer = converter.GetPlayer(player);
+      var hitController = pawn.Controller.Value?.As<CCSPlayerController>();
+
+      if (!config.FriendlyFireTriggers && hitController is { IsValid: true }) {
+        var apiPlayer = converter.GetPlayer(hitController);
         var role      = Roles.GetRoles(apiPlayer);
         if (role.Any(r => r is TraitorRole)) continue;
       }


### PR DESCRIPTION
## Problem

Surfaced now that the server no longer crashes (#6): the eye-trace hits a player's **pawn** (designer name `"player"`), but two callers asked `TryGetHitEntityByDesignerName<CCSPlayerController>("player", ...)`. The generic helper just does `As<T>()`, reinterpreting the **pawn** pointer as a **controller**. Reading controller-only schema fields off the pawn returns garbage:

- **`NameDisplayer`** printed a stray glyph (the `@` in-game) instead of the player's name.
- **`TripwireMovementListener`** read `SteamID`/`Index` off the bogus controller, so the `FriendlyFireTriggers` traitor check was unreliable (tripwires could trigger on the wrong targets).

## Fix

Resolve the controller from the pawn using the repo's existing idiom (`DamageCanceler`, `PlayerDamagedEvent`, `PistolRound` all do this):

```csharp
result.TryGetHitEntityByDesignerName<CCSPlayerPawn>("player", out var pawn);
var controller = pawn.Controller.Value?.As<CCSPlayerController>();
```

Then read `PlayerName` / look up the player from that controller, with an `IsValid` guard.

Also: `NameDisplayer` bailed the entire player loop with `return` on the first player not looking at anyone, so it only ever worked for the first iterated player. Changed to `continue`.

## Verification

`dotnet build TTT/CS2/CS2.csproj` (net10.0): **0 errors**. Needs an in-game check that the center-alert now shows the real player name and that tripwire friendly-fire still behaves. Builds on #6 (already merged to `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)