### PR TITLE
fix: restore body pickup/identification on E

### DIFF
--- a/TTT/CS2/GameHandlers/PropMover.cs
+++ b/TTT/CS2/GameHandlers/PropMover.cs
@@ -68,9 +68,10 @@ public class PropMover(IServiceProvider provider) : IPluginModule {
 
     if (!result.DidHit) return;
 
-    var entity = new CEntityInstance(result.HitEntity);
-    if (!entity.IsValid || !entity.DesignerName.Contains("player")) return;
-
+    // A body is a prop_ragdoll, not a "player" entity, so don't pre-filter the
+    // hit on a "player" designer name (that guard blocked all body pickup and
+    // identification). The ragdoll lookups below are guarded inside the
+    // extension, and the body tracker is the real "is this a body?" filter.
     result.TryGetHitEntityByDesignerName<CBaseEntity>("prop_ragdoll",
       out var hitEntity);
 


### PR DESCRIPTION
## Problem

Pressing **E** on a corpse does nothing — no pickup, no role identification.

The RayTrace refactor (`ce66a0c`) added this guard at the top of `PropMover.onStartUse`:

```csharp
var entity = new CEntityInstance(result.HitEntity);
if (!entity.IsValid || !entity.DesignerName.Contains("player")) return;
```

But a body is a `CRagdollProp` created via `CreateEntityByName<CRagdollProp>("prop_ragdoll")` — its **designer name is `"prop_ragdoll"`**, which does not contain `"player"`. (The `player_body__<index>` string is the entity *name*, not the designer name.) So aiming at a body returns early, **no `PropPickupEvent` is dispatched**, and therefore the downstream `BodyPickupListener.OnPropPickup → BodyIdentifyEvent` chain never runs. Both dragging and identifying bodies are broken.

The pre-refactor code had no such guard — it looked for `prop_ragdoll` / `prop_physics_multiplayer` directly.

## Fix

Remove the bogus guard. Safe because:
- The `prop_ragdoll` / `prop_physics_multiplayer` lookups are guarded inside `TryGetHitEntityByDesignerName` (null/`IsValid` checked), so a world/wall hit just yields `hitEntity == null` and returns at the existing `if (hitEntity == null) return;`.
- `BodyTracker.TryLookup(ev.Prop.Index)` in `BodyPickupListener` is the real "is this a tracked body?" filter, so non-body ragdolls won't identify.

## Verification

`dotnet build TTT/CS2/CS2.csproj` (net10.0): **0 errors**. Needs an in-game check: kill a player, aim at the corpse, press E → expect the "identified the body of … (role)" message and the ragdoll recoloring to the role color.

Note: independent of the earlier null-pointer fix (#6) and name-display fix (#7); this guard predates both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)