### PR TITLE
fix: stop tripwire purchase from crashing the server (SetModel before spawn)

### DIFF
--- a/TTT/CS2/Items/Tripwire/TripwireItem.cs
+++ b/TTT/CS2/Items/Tripwire/TripwireItem.cs
@@ -138,9 +138,13 @@ public class TripwireItem(IServiceProvider provider)
     tripwire = Utilities.CreateEntityByName<CDynamicProp>("prop_dynamic");
     if (tripwire == null) return false;
 
+    // DispatchSpawn must run before SetModel: SetModel -> SetupModel asserts the
+    // entity is no longer in the staging list (EF_IN_STAGING_LIST), which is
+    // only cleared by DispatchSpawn. Setting the (skeletal) conveyor model while
+    // still staged hard-crashes the server.
+    tripwire.DispatchSpawn();
     tripwire.SetModel(
       "models/generic/conveyor_control_panel_01/conveyor_button_02.vmdl");
-    tripwire.DispatchSpawn();
 
     tripwire.Teleport(originTrace.Value.EndPos.toVector(),
       originTrace.Value.Normal.toVector().toAngle());


### PR DESCRIPTION
## Problem

Buying a tripwire (`/shop` → tripwire) **hard-crashes the server**. Reproduced live; confirmed it's a native crash (no managed exception logged, no breakpad/Accelerator dump), and it happens in the same server run where the health/damage stations work — so it is **not** a precache, model-path, or trace issue.

The console shows the real cause repeatedly:
```
../../game/shared/skeletoninstance.cpp (5134) : Assertion Failed in function SetupModel():
0 == ( pInstance->GetOwnerEntity()->GetEntityIdentity()->GetFlags() & EF_IN_STAGING_LIST )
```

`placeTripwire` did:
```csharp
tripwire = Utilities.CreateEntityByName<CDynamicProp>("prop_dynamic");
tripwire.SetModel(".../conveyor_button_02.vmdl");  // entity still in staging list
tripwire.DispatchSpawn();
```

`SetModel` → `SetupModel` asserts the entity is **not** in the staging list (`EF_IN_STAGING_LIST`), and that flag is only cleared by `DispatchSpawn`. The `conveyor_button_02` model has a skeleton, so `SetupModel` runs and the assertion **hard-crashes** the process on every purchase.

The health/damage `StationItem` uses the same SetModel-before-DispatchSpawn order but its model (`microwave`) has no skeleton, so it never exercises `SetupModel` and survives — which is why stations work and tripwire doesn't.

## Fix

`DispatchSpawn()` first, then `SetModel()`.

## Verification

`dotnet build TTT/CS2/CS2.csproj` (net10.0): **0 errors**. Needs in-game confirmation: as a Traitor, buy a tripwire — server should no longer crash and the prop should appear.

## Follow-up (separate, not in this PR)
`RoleIconsHandler.cs:134` (`pawn.SetModel(...)` on team switch) is the source of the *recurring, non-fatal* `SetupModel`/`EF_IN_STAGING_LIST` assertion in the logs — same root cause class, worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)