### PR TITLE
fix: defer pawn SetModel on role assign (SetupModel staging assertion)

### DIFF
--- a/TTT/CS2/GameHandlers/RoleIconsHandler.cs
+++ b/TTT/CS2/GameHandlers/RoleIconsHandler.cs
@@ -131,7 +131,17 @@ public class RoleIconsHandler(IServiceProvider provider)
     var pawn = player.Pawn.Value;
     if (pawn == null || !pawn.IsValid) return;
 
-    pawn.SetModel(ev.Role is DetectiveRole ? CT_MODEL : T_MODEL);
+    // Defer the model swap: SwitchTeam above can respawn the pawn, putting it
+    // back in the staging list (EF_IN_STAGING_LIST). SetModel -> SetupModel
+    // asserts the pawn is no longer staged, so calling it synchronously here
+    // throws that assertion every team switch. Re-fetch the (possibly new) pawn
+    // next world update, once it has finished spawning.
+    var model = ev.Role is DetectiveRole ? CT_MODEL : T_MODEL;
+    Server.NextWorldUpdate(() => {
+      var spawned = players.GetPlayer(ev.Player)?.Pawn.Value;
+      if (spawned is { IsValid: true }) spawned.SetModel(model);
+    });
+
     assignIcon(player, ev.Role);
 
     switch (ev.Role) {


### PR DESCRIPTION
## Problem

Every team switch logs this engine assertion (seen firing repeatedly during play):
```
../../game/shared/skeletoninstance.cpp (5134) : Assertion Failed in function SetupModel():
0 == ( pInstance->GetOwnerEntity()->GetEntityIdentity()->GetFlags() & EF_IN_STAGING_LIST )
```

`RoleIconsHandler.OnAssigned` calls `player.SwitchTeam(...)` and then **synchronously** `pawn.SetModel(...)` in the same frame. `SwitchTeam` can respawn the pawn, putting it back in the staging list (`EF_IN_STAGING_LIST`); `SetModel` → `SetupModel` asserts the pawn is no longer staged, so it throws on every assignment.

It's non-fatal today (constant log noise), but it's the same root-cause class as the tripwire crash (#9) — `SetModel` on a staged entity — and is fragile.

## Fix

Defer the model swap to the next world update and re-fetch the (possibly recreated) pawn once it has finished spawning, so it's out of the staging list before `SetModel` runs.

## Verification

`dotnet build TTT/CS2/CS2.csproj` (net10.0): **0 errors**. In-game: after a round/role assignment, the `SetupModel` / `EF_IN_STAGING_LIST` assertions should no longer appear in the console, and detective/traitor models should still apply.

Companion to #9 (tripwire crash). Independent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)