### PR TITLE
fix: tripwire crash — pass pawn (not controller) as TraceShape ignore

### DIFF
--- a/TTT/CS2/Items/Tripwire/TripwireItem.cs
+++ b/TTT/CS2/Items/Tripwire/TripwireItem.cs
@@ -125,8 +125,12 @@ public class TripwireItem(IServiceProvider provider)
 
     var angles = originTrace.Value.Normal.toVector().toAngle();
 
+    // Ignore the player's PAWN, not the controller. TraceShape dereferences the
+    // ignore entity's collidable to build the trace filter; a CCSPlayerController
+    // has no collidable, so passing it crashes the server inside
+    // CRayTrace::TraceShapeInternal. The pawn is the body we want excluded anyway.
     var isSuccess = EgoApi.RAY_TRACE.Get()!
-     .TraceShape(originTrace.Value.EndPos.toVector(), angles, gamePlayer,
+     .TraceShape(originTrace.Value.EndPos.toVector(), angles, playerPawn,
         new TraceOptions {
           DrawBeam         = 0,
           InteractsWith    = (ulong)InteractionLayers.MASK_SHOT_FULL,


### PR DESCRIPTION
## Root cause (from a gameplay core dump)

Buying a tripwire crashes the server. A core dump from an actual purchase resolves the faulting frame precisely:

```
#0  RayTracePlugin::RayTrace::CRayTrace::TraceShapeInternal(
        Vector const&, QAngle const&, CEntityInstance*, TraceOptions const*) + 132
#1+ libcoreclr.so        ← the C# plugin P/Invoking TraceShape
```

That's `placeTripwire`'s `TraceShape(origin, angles, gamePlayer, options)`. It passed **`gamePlayer` — a `CCSPlayerController`** as the ignore entity. `TraceShapeInternal` dereferences the ignore entity's **collidable** to build the trace filter, but a controller has **no collidable**, so it dereferences a null sub-pointer and SIGSEGVs at +132. The working `checkTripwires` call passes `null` and never crashes.

## Fix

Pass **`playerPawn`** as the ignore entity. It's already fetched and null-checked at the top of `placeTripwire`, it's a real collision entity, and the player's own body is exactly what the placement trace should exclude.

```diff
- .TraceShape(originTrace.Value.EndPos.toVector(), angles, gamePlayer, ...)
+ .TraceShape(originTrace.Value.EndPos.toVector(), angles, playerPawn, ...)
```

## Notes
- The earlier `SetModel`/`DispatchSpawn` reorder (#9) was a **red herring** — the crash happens at this trace call, *before* the spawn code is reached. #9 is harmless (and arguably still more correct), so I've left it in.
- Diagnosis method: `systemd-coredump` core → gdb/`info symbol` + `nm -DC` on `RayTrace.so` resolved the offset to `TraceShapeInternal`.

## Verification

`dotnet build TTT/CS2/CS2.csproj` (net10.0): **0 errors**. Needs the in-game confirmation we can finally do now that the server is healthy: as a Traitor, buy a tripwire → expect it to place (a button prop on the aimed surface) with **no crash**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)