### PR TITLE
ci: trigger GitLab image build for main (build prod :latest)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,13 +76,16 @@ jobs:
   post_webhook:
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/dev'
+    if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main'
 
     steps:
       - name: POST Webhook
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_SECRET_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           curl -X POST \
             --fail \
-            -F token=${{ secrets.GITLAB_SECRET_TOKEN }} \
-            -F ref=dev \
+            -F token="$GITLAB_TOKEN" \
+            -F ref="$REF_NAME" \
             https://gitlab.edgegamers.io/api/v4/projects/2640/trigger/pipeline


### PR DESCRIPTION
## Problem
The `post_webhook` job in `nightly.yml` that pings the GitLab pipeline (project 2640) to build the server Docker image only fired for **dev**:
```yaml
if: github.ref == 'refs/heads/dev'
```
So merging to `main` built the plugin artifact but **never rebuilt the prod `ttt:latest` image** — prod can't pick up `main` changes.

## Fix
Fire the webhook for `main` too, sending the matching ref so `dev → :dev` and `main → :latest`:
```yaml
if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main'
...
-F ref="$REF_NAME"   # github.ref_name, passed via env (injection-safe)
```

## Caveat
This assumes GitLab project 2640 builds `:latest` when triggered with `ref=main`. If the recent **manual main pipeline failed on the GitLab side**, this GitHub change won't fix that — that'd be a GitLab-project config issue (e.g., no `main` branch / job rules). Need the GitLab error to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)