### PR TITLE
fix: tripwire beams accumulate — remove entities on round end

### DIFF
--- a/TTT/CS2/Items/Tripwire/TripwireItem.cs
+++ b/TTT/CS2/Items/Tripwire/TripwireItem.cs
@@ -78,6 +78,14 @@ public class TripwireItem(IServiceProvider provider)
   [EventHandler]
   public void OnGameEvent(GameStateUpdateEvent ev) {
     if (ev.NewState != State.FINISHED) return;
+    // Remove the beam + prop entities, not just the list entries — otherwise
+    // untriggered tripwires leak their env_beam/prop every round and the beams
+    // accumulate across rounds.
+    foreach (var instance in ActiveTripwires) {
+      instance.Beam.Remove();
+      instance.TripwireProp.Remove();
+    }
+
     ActiveTripwires.Clear();
   }
 

--- a/TTT/CS2/Items/Tripwire/TripwireItem.cs
+++ b/TTT/CS2/Items/Tripwire/TripwireItem.cs
@@ -184,6 +184,9 @@ public class TripwireItem(IServiceProvider provider)
     beam.EndPos.Y   = end.Y;
     beam.EndPos.Z   = end.Z;
     beam.Teleport(start);
+    // Spawn the beam so it's a fully-registered entity; otherwise Remove()
+    // doesn't reliably destroy it and the beam lingers.
+    beam.DispatchSpawn();
     return beam;
   }
 }


### PR DESCRIPTION
## Problem
Stray translucent beams build up on the map (screenshotted). They're leaked **`env_beam`** entities from tripwires.

`TripwireItem.OnGameEvent` on round end (`State.FINISHED`) did:
```csharp
ActiveTripwires.Clear();   // empties the list but never removes the entities
```
`RemoveTripwire()` correctly does `Beam.Remove()` + `TripwireProp.Remove()` (used when a tripwire is *triggered*), but a tripwire that's **never triggered** just gets dropped from the list at round end while its `env_beam`/`prop_dynamic` stay alive. So every round leaves its placed-but-untriggered tripwire beams behind, and they pile up across rounds.

## Fix
Remove each tracked instance's `Beam` and `TripwireProp` before clearing the list:
```csharp
foreach (var instance in ActiveTripwires) {
  instance.Beam.Remove();
  instance.TripwireProp.Remove();
}
ActiveTripwires.Clear();
```

## Verification
`dotnet build TTT/CS2/CS2.csproj` (net10.0): 0 errors. In-game: place tripwires, end the round → beams/props should be gone next round instead of persisting.

Note: All `DrawBeam` trace options are `0`, so this is entity leakage, not RayTrace debug-beam drawing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)