### PR TITLE
fix: drag-beam (body/station pickup) not removed on release

### DIFF
--- a/TTT/CS2/GameHandlers/PropMover.cs
+++ b/TTT/CS2/GameHandlers/PropMover.cs
@@ -100,7 +100,7 @@ public class PropMover(IServiceProvider provider) : IPluginModule {
     playersPressingE.Remove(player);
     if (!heldItem.Ragdoll.IsValid) return;
     if (heldItem.Beam != null && heldItem.Beam.IsValid)
-      heldItem.Beam.AcceptInput("Kill");
+      heldItem.Beam.Remove();
     // Check if any other players are still holding this ragdoll
     foreach (var (_, info) in playersPressingE)
       if (info.Ragdoll == heldItem.Ragdoll)
@@ -204,7 +204,7 @@ public class PropMover(IServiceProvider provider) : IPluginModule {
     if (ent.AbsOrigin == null) return;
 
     if (info.Beam != null && info.Beam.IsValid) {
-      info.Beam.AcceptInput("Kill");
+      info.Beam.Remove();
       info.Beam = createBeam(playerOrigin.With(z: playerOrigin.Z - 16),
         ent.AbsOrigin);
     }

--- a/TTT/CS2/GameHandlers/PropMover.cs
+++ b/TTT/CS2/GameHandlers/PropMover.cs
@@ -222,6 +222,9 @@ public class PropMover(IServiceProvider provider) : IPluginModule {
     beam.EndPos.Y   = end.Y;
     beam.EndPos.Z   = end.Z;
     beam.Teleport(start);
+    // Spawn the beam so it's a fully-registered entity; otherwise Remove()/Kill
+    // don't reliably destroy it and the beam lingers.
+    beam.DispatchSpawn();
     return beam;
   }
 }


### PR DESCRIPTION
## Problem
The white beam shown while holding **E** to drag a body or a station prop (`prop_physics_multiplayer`) doesn't get removed — stray white lines stay on the map after you let go.

`PropMover` removed the `env_beam` via `AcceptInput("Kill")`, which **doesn't reliably destroy `env_beam`** in CS2. Worse, `refreshLines` recreates the beam **every tick** (to follow the prop) and `Kill`s the previous one — so while dragging, "killed"-but-not-removed beams pile up, and on release only the last is `Kill`ed → leftover lines everywhere.

## Fix
Use `CEnvBeam.Remove()` (native removal — the same call the tripwire code uses) instead of `AcceptInput("Kill")`, in both:
- `refreshLines` (per-tick recreate)
- `onCeaseUse` (on release)

## Verification
`dotnet build TTT/CS2/CS2.csproj` (net10.0): 0 errors. In-game: hold E to drag a body / station prop, release → the white beam should disappear immediately, with no buildup while dragging.

Companion to #14 (tripwire beams leaking on round end — same `env_beam` family, different code path). This one is the body/station pickup beam the report was actually about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)