### PR TITLE
fix: reuse drag-beam (stop per-tick env_beam pile-up while carrying)

### DIFF
--- a/TTT/CS2/GameHandlers/PropMover.cs
+++ b/TTT/CS2/GameHandlers/PropMover.cs
@@ -204,9 +204,14 @@ public class PropMover(IServiceProvider provider) : IPluginModule {
     if (ent.AbsOrigin == null) return;
 
     if (info.Beam != null && info.Beam.IsValid) {
-      info.Beam.Remove();
-      info.Beam = createBeam(playerOrigin.With(z: playerOrigin.Z - 16),
-        ent.AbsOrigin);
+      // Reuse the single beam — move its start + end each tick instead of
+      // recreating it. env_beam removal is unreliable, so the old recreate-
+      // every-tick approach leaked a fresh beam every tick while carrying.
+      info.Beam.Teleport(playerOrigin.With(z: playerOrigin.Z - 16));
+      info.Beam.EndPos.X = ent.AbsOrigin.X;
+      info.Beam.EndPos.Y = ent.AbsOrigin.Y;
+      info.Beam.EndPos.Z = ent.AbsOrigin.Z;
+      Utilities.SetStateChanged(info.Beam, "CBeam", "m_vecEndPos");
     }
 
     playersPressingE[player] = info;


### PR DESCRIPTION
## Problem
Carrying a body/station prop (hold E) spawns a new white beam **every tick** that never goes away — lines pile up across the map. Confirmed: it's `refreshLines` recreating the `env_beam` each tick, and `env_beam` removal is unreliable (`Kill`, `.Remove()`, even on a `DispatchSpawn`'d beam all failed to destroy it — prior PRs #14/#15 didn't fix the buildup).

## Fix
Stop recreating. Keep **one** beam for the whole carry and just move it each tick: `Teleport` the start and update `EndPos` + `SetStateChanged(beam,"CBeam","m_vecEndPos")`. One beam, no buildup — independent of whether `env_beam` removal works.

## Verification
`dotnet build` (net10.0): 0 errors. Needs in-game: carry a body, move around → a single beam should follow with **no** accumulating lines.

Caveat: if the endpoint-update networking doesn't move the beam smoothly it may look static, but it won't pile up. Supersedes the recreate approach in #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)