### PR TITLE
Promote dev → main: beam-leak fixes + CI image trigger

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,13 +76,16 @@ jobs:
   post_webhook:
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/dev'
+    if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main'
 
     steps:
       - name: POST Webhook
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_SECRET_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           curl -X POST \
             --fail \
-            -F token=${{ secrets.GITLAB_SECRET_TOKEN }} \
-            -F ref=dev \
+            -F token="$GITLAB_TOKEN" \
+            -F ref="$REF_NAME" \
             https://gitlab.edgegamers.io/api/v4/projects/2640/trigger/pipeline

--- a/TTT/CS2/GameHandlers/PropMover.cs
+++ b/TTT/CS2/GameHandlers/PropMover.cs
@@ -100,7 +100,7 @@ public class PropMover(IServiceProvider provider) : IPluginModule {
     playersPressingE.Remove(player);
     if (!heldItem.Ragdoll.IsValid) return;
     if (heldItem.Beam != null && heldItem.Beam.IsValid)
-      heldItem.Beam.AcceptInput("Kill");
+      heldItem.Beam.Remove();
     // Check if any other players are still holding this ragdoll
     foreach (var (_, info) in playersPressingE)
       if (info.Ragdoll == heldItem.Ragdoll)
@@ -204,7 +204,7 @@ public class PropMover(IServiceProvider provider) : IPluginModule {
     if (ent.AbsOrigin == null) return;
 
     if (info.Beam != null && info.Beam.IsValid) {
-      info.Beam.AcceptInput("Kill");
+      info.Beam.Remove();
       info.Beam = createBeam(playerOrigin.With(z: playerOrigin.Z - 16),
         ent.AbsOrigin);
     }

--- a/TTT/CS2/GameHandlers/PropMover.cs
+++ b/TTT/CS2/GameHandlers/PropMover.cs
@@ -204,9 +204,14 @@ public class PropMover(IServiceProvider provider) : IPluginModule {
     if (ent.AbsOrigin == null) return;
 
     if (info.Beam != null && info.Beam.IsValid) {
-      info.Beam.Remove();
-      info.Beam = createBeam(playerOrigin.With(z: playerOrigin.Z - 16),
-        ent.AbsOrigin);
+      // Reuse the single beam — move its start + end each tick instead of
+      // recreating it. env_beam removal is unreliable, so the old recreate-
+      // every-tick approach leaked a fresh beam every tick while carrying.
+      info.Beam.Teleport(playerOrigin.With(z: playerOrigin.Z - 16));
+      info.Beam.EndPos.X = ent.AbsOrigin.X;
+      info.Beam.EndPos.Y = ent.AbsOrigin.Y;
+      info.Beam.EndPos.Z = ent.AbsOrigin.Z;
+      Utilities.SetStateChanged(info.Beam, "CBeam", "m_vecEndPos");
     }
 
     playersPressingE[player] = info;

--- a/TTT/CS2/GameHandlers/PropMover.cs
+++ b/TTT/CS2/GameHandlers/PropMover.cs
@@ -222,6 +222,9 @@ public class PropMover(IServiceProvider provider) : IPluginModule {
     beam.EndPos.Y   = end.Y;
     beam.EndPos.Z   = end.Z;
     beam.Teleport(start);
+    // Spawn the beam so it's a fully-registered entity; otherwise Remove()/Kill
+    // don't reliably destroy it and the beam lingers.
+    beam.DispatchSpawn();
     return beam;
   }
 }

--- a/TTT/CS2/Items/Tripwire/TripwireItem.cs
+++ b/TTT/CS2/Items/Tripwire/TripwireItem.cs
@@ -78,6 +78,14 @@ public class TripwireItem(IServiceProvider provider)
   [EventHandler]
   public void OnGameEvent(GameStateUpdateEvent ev) {
     if (ev.NewState != State.FINISHED) return;
+    // Remove the beam + prop entities, not just the list entries — otherwise
+    // untriggered tripwires leak their env_beam/prop every round and the beams
+    // accumulate across rounds.
+    foreach (var instance in ActiveTripwires) {
+      instance.Beam.Remove();
+      instance.TripwireProp.Remove();
+    }
+
     ActiveTripwires.Clear();
   }
 

--- a/TTT/CS2/Items/Tripwire/TripwireItem.cs
+++ b/TTT/CS2/Items/Tripwire/TripwireItem.cs
@@ -184,6 +184,9 @@ public class TripwireItem(IServiceProvider provider)
     beam.EndPos.Y   = end.Y;
     beam.EndPos.Z   = end.Z;
     beam.Teleport(start);
+    // Spawn the beam so it's a fully-registered entity; otherwise Remove()
+    // doesn't reliably destroy it and the beam lingers.
+    beam.DispatchSpawn();
     return beam;
   }
 }


### PR DESCRIPTION
Promotes `dev` to `main` for tagging + live deploy.

New since last `main`:
- **#13** — fire the GitLab image-build webhook for `main` too (so prod `:latest` rebuilds; was dev-only)
- **#14** — remove tripwire beam/prop entities on round end (stop cross-round buildup)
- **#15** — drag-beam: use `.Remove()` + `DispatchSpawn` instead of `Kill`
- **#16** — drag-beam: reuse one beam (move it) instead of recreating every tick — fixes the lines piling up while carrying a body/station prop

Already on `main` from before: TraceResult null-ptr guard, name display, body-ID on E, tripwire TraceShape crash fix, RoleIcons assertion.

After merge: cut a GitLab tag on project 2640 (e.g. `26.06.24.1`) → builds `:latest` → `docker compose pull cs2 && up -d cs2` on `cs2-prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)