### PR TITLE
fix: round sometimes never ends + mid-round joiner bugs out

### DIFF
--- a/TTT/CS2/GameHandlers/LateSpawnListener.cs
+++ b/TTT/CS2/GameHandlers/LateSpawnListener.cs
@@ -21,7 +21,18 @@ public class LateSpawnListener(IServiceProvider provider)
   [UsedImplicitly]
   [EventHandler]
   public void OnJoin(PlayerJoinEvent ev) {
-    if (Games.ActiveGame is { State: State.IN_PROGRESS }) return;
+    if (Games.ActiveGame is { State: State.IN_PROGRESS }) {
+      // A round is already running; late joiners can't be assigned a role
+      // mid-round, so park them in spectator until the next round instead of
+      // leaving them role-less and half-spawned.
+      Server.NextWorldUpdate(() => {
+        var player = converter.GetPlayer(ev.Player);
+        if (player == null || !player.IsValid) return;
+        if (player.Team is not (CsTeam.Spectator or CsTeam.None))
+          player.ChangeTeam(CsTeam.Spectator);
+      });
+      return;
+    }
 
     Server.NextWorldUpdate(() => {
       var player = converter.GetPlayer(ev.Player);

--- a/TTT/CS2/Listeners/RoundTimerListener.cs
+++ b/TTT/CS2/Listeners/RoundTimerListener.cs
@@ -26,6 +26,7 @@ public class RoundTimerListener(IServiceProvider provider)
     provider.GetRequiredService<IPlayerConverter<CCSPlayerController>>();
 
   public IDisposable? EndTimer;
+  public IDisposable? SafetyTimer;
 
   private TTTConfig config
     => Provider.GetRequiredService<IStorage<TTTConfig>>()
@@ -63,7 +64,10 @@ public class RoundTimerListener(IServiceProvider provider)
           player.Respawn();
       });
 
-    if (ev.NewState == State.FINISHED) EndTimer?.Dispose();
+    if (ev.NewState == State.FINISHED) {
+      EndTimer?.Dispose();
+      SafetyTimer?.Dispose();
+    }
     if (ev.NewState != State.IN_PROGRESS) return;
     var duration = config.RoundCfg.RoundDuration(ev.Game.Players.Count);
     Server.NextWorldUpdate(()
@@ -75,6 +79,13 @@ public class RoundTimerListener(IServiceProvider provider)
         Server.NextWorldUpdate(()
           => ev.Game.EndGame(EndReason.TIMEOUT(new InnocentRole(Provider))));
       });
+
+    // Safety net: round-end is otherwise only checked on death/leave events; if
+    // any single trigger is missed the round hangs forever. Re-check ~1x/sec
+    // while in progress so it always converges (no-op once FINISHED).
+    SafetyTimer?.Dispose();
+    SafetyTimer = Observable.Interval(TimeSpan.FromSeconds(1), Scheduler)
+     .Subscribe(_ => Server.NextWorldUpdate(() => ev.Game.CheckEndConditions()));
   }
 
   [UsedImplicitly]
@@ -138,5 +149,6 @@ public class RoundTimerListener(IServiceProvider provider)
     base.Dispose();
 
     EndTimer?.Dispose();
+    SafetyTimer?.Dispose();
   }
 }

--- a/TTT/Game/RoundBasedGame.cs
+++ b/TTT/Game/RoundBasedGame.cs
@@ -137,9 +137,16 @@ public class RoundBasedGame(IServiceProvider provider) : IGame {
     var detectiveRole = Roles.First(r
       => r.GetType().IsAssignableTo(typeof(DetectiveRole)));
 
-    var traitorsAlive    = ((IGame)this).GetAlive(typeof(TraitorRole)).Count;
-    var nonTraitorsAlive = ((IGame)this).GetAlive().Count - traitorsAlive;
-    var detectivesAlive  = ((IGame)this).GetAlive(typeof(DetectiveRole)).Count;
+    // Single pass over alive role-holders (cheaper + allocation-free than 3x
+    // GetAlive(); counts are equivalent: non-traitors = innocents + detectives).
+    int traitorsAlive = 0, nonTraitorsAlive = 0, detectivesAlive = 0;
+    foreach (var p in Players.OfType<IOnlinePlayer>()) {
+      if (!p.IsAlive) continue;
+      var pRoles = RoleAssigner.GetRoles(p);
+      if (pRoles.Any(r => r is TraitorRole)) { traitorsAlive++; continue; }
+      nonTraitorsAlive++;
+      if (pRoles.Any(r => r is DetectiveRole)) detectivesAlive++;
+    }
 
     switch (traitorsAlive) {
       case 0 when nonTraitorsAlive == 0:


### PR DESCRIPTION
## Bug 1 — round sometimes never ends
Win conditions were evaluated **only** on `PlayerDeathEvent`/`PlayerLeaveEvent`. With no periodic re-check, any single missed trigger (a death that doesn't dispatch the event, a handler throwing before `PlayerCausesEndListener`, a dropped `NextWorldUpdateAsync`, a stale count at the deciding moment) leaves the round hung forever.

**Fix:** add a **1 Hz safety re-check** in `RoundTimerListener` (reuses the existing Rx `Scheduler`, disposed on round end) that calls `CheckEndConditions()` while `IN_PROGRESS`. Round-end now self-corrects within ~1s no matter which trigger fired. Negligible cost (64x less frequent than existing per-tick loops). Also rewrote `getWinningTeam` to a single allocation-free pass instead of 3× `GetAlive()`.

## Bug 2 — joining mid-round bugs out
`LateSpawnListener.OnJoin` returned early during `IN_PROGRESS` without handling the joiner → role-less, half-spawned player. Now parks late joiners in **spectator** until the next round (they get a role normally next round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)