### PR TITLE
fix: random, rotating traitor/role selection (was deterministic by SteamID)

### DIFF
--- a/TTT/API/Role/IRoleAssigner.cs
+++ b/TTT/API/Role/IRoleAssigner.cs
@@ -26,4 +26,12 @@ public interface IRoleAssigner : IKeyedStorage<IPlayer, ICollection<IRole>>,
   public ICollection<IRole> GetRoles(IPlayer player) {
     return Load(player).GetAwaiter().GetResult() ?? [];
   }
+
+  /// <summary>
+  ///   Roles this player held in the *previous* round (empty if none / first
+  ///   round). Used by role selection to rotate roles between rounds.
+  /// </summary>
+  public ICollection<IRole> GetPreviousRoles(IPlayer player) {
+    return [];
+  }
 }

--- a/TTT/Game/Roles/RatioBasedRole.cs
+++ b/TTT/Game/Roles/RatioBasedRole.cs
@@ -5,6 +5,8 @@ namespace TTT.Game.Roles;
 
 public abstract class RatioBasedRole(IServiceProvider provider)
   : BaseRole(provider) {
+  private static readonly Random rng = new();
+
   public override abstract string Id { get; }
   public override abstract string Name { get; }
   public override abstract Color Color { get; }
@@ -15,10 +17,20 @@ public abstract class RatioBasedRole(IServiceProvider provider)
     FindPlayerToAssign(ISet<IOnlinePlayer> players) {
     var currentCount =
       players.Count(p => Roles.GetRoles(p).Any(r => r.Id == Id));
-    var targetCountValue = TargetCount(players.Count);
+    if (currentCount >= TargetCount(players.Count)) return null;
 
-    return currentCount >= targetCountValue ?
-      null : // No need to assign this role
-      players.FirstOrDefault(p => Roles.GetRoles(p).Count == 0);
+    var candidates =
+      players.Where(p => Roles.GetRoles(p).Count == 0).ToList();
+    if (candidates.Count == 0) return null;
+
+    // Prefer players who did NOT hold this role last round so roles rotate
+    // (classic TTT behaviour). 1-in-6 chance to ignore the preference so we
+    // never starve when few "fresh" candidates remain.
+    var fresh = candidates
+     .Where(p => Roles.GetPreviousRoles(p).All(r => r.Id != Id))
+     .ToList();
+    var pool = fresh.Count > 0 && rng.Next(6) != 0 ? fresh : candidates;
+
+    return pool[rng.Next(pool.Count)];
   }
 }

--- a/TTT/Game/Roles/RoleAssigner.cs
+++ b/TTT/Game/Roles/RoleAssigner.cs
@@ -8,9 +8,10 @@ using TTT.Game.Events.Player;
 namespace TTT.Game.Roles;
 
 public class RoleAssigner(IServiceProvider provider) : IRoleAssigner {
-  private static readonly Random rng = new();
-
   private readonly IDictionary<string, ICollection<IRole>> assignedRoles =
+    new Dictionary<string, ICollection<IRole>>();
+
+  private IDictionary<string, ICollection<IRole>> lastRoles =
     new Dictionary<string, ICollection<IRole>>();
 
   private readonly IEventBus bus = provider.GetRequiredService<IEventBus>();
@@ -19,10 +20,21 @@ public class RoleAssigner(IServiceProvider provider) : IRoleAssigner {
     provider.GetService<IMessenger>();
 
   public void AssignRoles(ISet<IOnlinePlayer> players, IList<IRole> roles) {
+    // Snapshot the previous round's assignments before clearing so role
+    // selection can avoid handing a player the same role twice in a row.
+    lastRoles = new Dictionary<string, ICollection<IRole>>(assignedRoles);
     assignedRoles.Clear();
-    var  shuffled = players.OrderBy(_ => rng.NextDouble()).ToHashSet();
+
+    // Selection is randomized per-role in RatioBasedRole.FindPlayerToAssign,
+    // so no pre-shuffle is needed (the old OrderBy(...).ToHashSet() shuffle was
+    // discarded by ToHashSet anyway, making picks deterministic by SteamID).
+    var pool = players.ToHashSet();
     bool roleAssigned;
-    do { roleAssigned = tryAssignRole(shuffled, roles); } while (roleAssigned);
+    do { roleAssigned = tryAssignRole(pool, roles); } while (roleAssigned);
+  }
+
+  public ICollection<IRole> GetPreviousRoles(IPlayer player) {
+    return lastRoles.TryGetValue(player.Id, out var roles) ? roles : [];
   }
 
   public Task<ICollection<IRole>?> Load(IPlayer key) {


### PR DESCRIPTION
## Problem
Role selection was effectively **deterministic, not random**. `AssignRoles` shuffled with `OrderBy(rng).ToHashSet()`, but **`ToHashSet()` discards the shuffled order**, and `RatioBasedRole.FindPlayerToAssign` then picked `FirstOrDefault(unassigned)` — i.e. players in **SteamID-hash order, identical every round**. Result: the same players keep getting traitor.

Compared against the canonical CS:GO TTT plugin ([TroubleinTerroristTown/Public](https://github.com/TroubleinTerroristTown/Public)), which picks a **random** player each iteration and **avoids repeating last round's role** (`LastRole` check with a 1-in-6 override).

## Fix
- `RatioBasedRole.FindPlayerToAssign`: uniformly **random** unassigned candidate, **preferring players who did not hold this role last round** (1-in-6 chance to ignore so it never starves).
- `RoleAssigner`: snapshots the previous round's roles (`lastRoles`) and exposes `IRoleAssigner.GetPreviousRoles`; removed the order-destroying shuffle.
- **Counts/balance unchanged** — `RoleAssignerTest` balance theory still holds (assertions are on counts, not specific players).

## Follow-up
Karma-weighted **detective** selection (prefer high-karma innocents) belongs in the **Karma** project via the cancelable `PlayerRoleAssignEvent` — `TTT.Game` can't reference `TTT.Karma`. Can do as a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)