### PR TITLE
fix: per-bullet 'Schema target points to null' spam (tripwire/station bullet impact)

### DIFF
--- a/TTT/CS2/Items/Station/StationItem.cs
+++ b/TTT/CS2/Items/Station/StationItem.cs
@@ -64,10 +64,13 @@ public abstract class StationItem<T>(IServiceProvider provider,
   public HookResult OnBulletImpact(EventBulletImpact ev, GameEventInfo info) {
     var hitVec = new Vector(ev.X, ev.Y, ev.Z);
 
+    // Filter out invalid/removed props BEFORE dereferencing AbsOrigin —
+    // computing Distance in the Select first threw on invalid entities
+    // ("Schema target points to null") every bullet impact.
     var nearest = Props
+     .Where(kv => kv.Key is { IsValid: true, AbsOrigin: not null })
      .Select(kv => (kv.Key, kv.Value,
         Distance: kv.Key.AbsOrigin!.DistanceSquared(hitVec)))
-     .Where(t => t.Key is { IsValid: true, AbsOrigin: not null })
      .OrderBy(t => t.Distance)
      .FirstOrDefault();
 

--- a/TTT/CS2/Items/Tripwire/TripwireDamageListener.cs
+++ b/TTT/CS2/Items/Tripwire/TripwireDamageListener.cs
@@ -33,12 +33,18 @@ public class TripwireDamageListener(IServiceProvider provider) : IPluginModule {
     if (tripwires == null) return HookResult.Continue;
     var hitVec = new Vector(ev.X, ev.Y, ev.Z);
 
+    // Skip tripwires whose prop has been removed/invalidated (still lingering
+    // in the list) — reading AbsOrigin on an invalid entity throws
+    // "Schema target points to null" on every bullet impact.
     var nearest = tripwires.ActiveTripwires
-     .OrderBy(wire => wire.TripwireProp.AbsOrigin.DistanceSquared(hitVec))
+     .Where(wire => wire.TripwireProp is { IsValid: true }
+        && wire.TripwireProp.AbsOrigin != null)
+     .OrderBy(wire => wire.TripwireProp.AbsOrigin!.DistanceSquared(hitVec))
      .FirstOrDefault();
 
     if (nearest == null) return HookResult.Continue;
-    var distSquared = nearest.TripwireProp.AbsOrigin.DistanceSquared(hitVec);
+    var distSquared =
+      nearest.TripwireProp.AbsOrigin!.DistanceSquared(hitVec);
     if (distSquared > config.TripwireSizeSquared) return HookResult.Continue;
 
     tripwireActivator?.ActivateTripwire(nearest);


### PR DESCRIPTION
## Problem
Found while reviewing prod logs:  floods with `[EROR] (cssharp:Core) Error invoking callback ... ArgumentNullException: Schema target points to null` on **every bullet impact**, from two handlers:

- `TripwireDamageListener.OnBulletImpact` — `wire.TripwireProp.AbsOrigin` with no validity check; a removed prop still in `ActiveTripwires` throws.
- `StationItem.OnBulletImpact` — the `Select` computes `kv.Key.AbsOrigin!.DistanceSquared(...)` **before** the `Where(IsValid)` filter, so invalid props throw (the `!` only silences the compiler).

**Impact:** heavy log spam + per-bullet exception overhead, and the shot's tripwire/station damage detection silently no-ops whenever an invalid entity is present.

## Fix
Guard / **before** dereferencing in both: filter invalid props out first, then order by distance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)