### PR TITLE
feat: per-round item purchase limits (cluster grenade 1/round)

### DIFF
--- a/TTT/Shop/Shop.cs
+++ b/TTT/Shop/Shop.cs
@@ -15,6 +15,10 @@ public class Shop(IServiceProvider provider) : ITerrorModule, IShop {
   private readonly IEventBus bus = provider.GetRequiredService<IEventBus>();
   private readonly Dictionary<string, List<IShopItem>> items = new();
 
+  // player.Id -> item type key -> times purchased this round
+  private readonly Dictionary<string, Dictionary<string, int>> purchaseCounts =
+    new();
+
   private readonly IMsgLocalizer localizer =
     provider.GetRequiredService<IMsgLocalizer>();
 
@@ -54,12 +58,35 @@ public class Shop(IServiceProvider provider) : ITerrorModule, IShop {
       return canPurchase;
     }
 
+    var purchaseLimit = item.Config.PurchaseLimit;
+    var itemKey       = item.GetType().FullName ?? item.Name;
+    if (purchaseLimit > 0
+      && purchaseCounts.TryGetValue(player.Id, out var owned)
+      && owned.GetValueOrDefault(itemKey, 0) >= purchaseLimit) {
+      if (printReason)
+        messenger?.Message(player,
+          localizer[
+            ShopMsgs.SHOP_CANNOT_PURCHASE_WITH_REASON(
+              PurchaseResult.ALREADY_OWNED.ToMessage())]);
+      return PurchaseResult.ALREADY_OWNED;
+    }
+
     var purchaseEvent = new PlayerPurchaseItemEvent(player, item);
     bus.Dispatch(purchaseEvent);
     if (purchaseEvent.IsCanceled) return PurchaseResult.PURCHASE_CANCELED;
 
     AddBalance(player, -cost, item.Name, printReason);
     GiveItem(player, item);
+
+    if (purchaseLimit > 0) {
+      if (!purchaseCounts.TryGetValue(player.Id, out var counts)) {
+        counts                    = new Dictionary<string, int>();
+        purchaseCounts[player.Id] = counts;
+      }
+
+      counts[itemKey] = counts.GetValueOrDefault(itemKey, 0) + 1;
+    }
+
     return PurchaseResult.SUCCESS;
   }
 
@@ -90,7 +117,7 @@ public class Shop(IServiceProvider provider) : ITerrorModule, IShop {
   }
 
   public void ClearBalances() { balances.Clear(); }
-  public void ClearItems() { items.Clear(); }
+  public void ClearItems() { items.Clear(); purchaseCounts.Clear(); }
 
   public void GiveItem(IOnlinePlayer player, IShopItem item) {
     if (!items.ContainsKey(player.Id)) items[player.Id] = [];

--- a/TTT/ShopAPI/Configs/ShopItemConfig.cs
+++ b/TTT/ShopAPI/Configs/ShopItemConfig.cs
@@ -2,4 +2,10 @@ namespace ShopAPI.Configs;
 
 public abstract record ShopItemConfig {
   public abstract int Price { get; init; }
+
+  /// <summary>
+  ///   Max times a single player may purchase this item per round.
+  ///   0 (default) = unlimited.
+  /// </summary>
+  public virtual int PurchaseLimit { get; init; }
 }

--- a/TTT/ShopAPI/Configs/Traitor/ClusterGrenadeConfig.cs
+++ b/TTT/ShopAPI/Configs/Traitor/ClusterGrenadeConfig.cs
@@ -4,6 +4,7 @@ namespace ShopAPI.Configs.Traitor;
 
 public record ClusterGrenadeConfig : ShopItemConfig, IWeapon {
   public override int Price { get; init; } = 100;
+  public override int PurchaseLimit { get; init; } = 1;
   public int GrenadeCount { get; init; } = 8;
   public float UpForce { get; init; } = 200f;
   public float ThrowForce { get; init; } = 300f;


### PR DESCRIPTION
## Per-round item purchase limits

**Problem:** items had no purchase cap, so a player could spam-buy (e.g. **ClusterGrenade** = 8 grenades each) and wipe all innocents.

**Fix:** a configurable per-round limit, mirroring what Shook started in the (closed/stale) `feat/itemLimits`, but implemented cleanly on current `dev`:
- `ShopItemConfig.PurchaseLimit` — `0` = unlimited (default; all existing items unchanged).
- `Shop.TryPurchase` enforces it per player per round (returns `ALREADY_OWNED` → "you have purchased the maximum amount of this item").
- Counts reset each round (`ClearItems`, already called by `RoundShopClearer` on round start).
- **ClusterGrenade limited to `1`/round.** Any other item can be capped by setting `PurchaseLimit` in its config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
