### PR TITLE
fix: rich round 2x starting credits (activation-ordering bug)

### DIFF
--- a/TTT/SpecialRound/Rounds/RichRound.cs
+++ b/TTT/SpecialRound/Rounds/RichRound.cs
@@ -1,5 +1,7 @@
+using CounterStrikeSharp.API;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
+using ShopAPI;
 using ShopAPI.Events;
 using SpecialRound.lang;
 using SpecialRoundAPI;
@@ -13,6 +15,10 @@ namespace SpecialRound.Rounds;
 
 public class RichRound(IServiceProvider provider)
   : AbstractSpecialRound(provider) {
+  private const string BONUS_REASON = "Rich Round Bonus";
+
+  private readonly IShop shop = provider.GetRequiredService<IShop>();
+
   public override string Name => "Rich";
   public override IMsg Description => RoundMsgs.SPECIAL_ROUND_RICH;
   public override SpecialRoundConfig Config => config;
@@ -23,19 +29,30 @@ public class RichRound(IServiceProvider provider)
      .GetAwaiter()
      .GetResult() ?? new RichRoundConfig();
 
-  public override void ApplyRoundEffects() { }
+  // The "Round Start" credits are granted (RoleAssignCreditor, partly on a
+  // background task) BEFORE this round is registered active, so intercepting
+  // that balance event never worked for the starting bonus. Instead, once the
+  // starting credits have landed (a few ticks after enable), double them
+  // directly. In-round gains are still multiplied via OnBalanceChange below.
+  public override void ApplyRoundEffects() {
+    Server.RunOnTick(Server.TickCount + 10, () => {
+      if (!Tracker.ActiveRounds.Contains(this)) return;
+      var mult = config.BonusCreditsMultiplier;
+      foreach (var player in Finder.GetOnline()) {
+        var bal = shop.Load(player).GetAwaiter().GetResult();
+        if (bal <= 0) continue;
+        var bonus = (int)(bal * (mult - 1f));
+        if (bonus != 0) shop.AddBalance(player, bonus, BONUS_REASON, false);
+      }
+    });
+  }
 
   [UsedImplicitly]
   [EventHandler]
   public void OnBalanceChange(PlayerBalanceEvent ev) {
     if (!Tracker.ActiveRounds.Contains(this)) return;
-    if (ev.Reason == "Round Start") {
-      var newBal = (int)(ev.NewBalance * config.BonusCreditsMultiplier);
-      ev.NewBalance = newBal;
-      return;
-    }
-
-    if (ev.NewBalance <= ev.OldBalance) return;
+    if (ev.Reason == BONUS_REASON) return; // our own grant — don't re-multiply
+    if (ev.NewBalance <= ev.OldBalance) return; // only multiply gains
 
     var gain = ev.NewBalance - ev.OldBalance;
     gain          = (int)(gain * config.AdditiveCreditsMultiplier);


### PR DESCRIPTION
## Rich round: 2× starting credits never applied (3× gains did)

**Root cause (ordering):** in `RoundBasedGame.StartRound`, `AssignRoles` → `RoleAssignCreditor` grants the `"Round Start"` credits **before** `State = IN_PROGRESS`, which is what activates the special round (`SpecialRoundStarter`). So when `RichRound.OnBalanceChange` saw the `"Round Start"` event, `Tracker.ActiveRounds.Contains(this)` was **false** → the 2× was skipped. (Made worse by `RoleAssignCreditor` granting on a background `Task.Run` for the karma path.) The 3× worked because kills/gains happen later, once the round is active.

**Fix:** stop relying on the mistimed `"Round Start"` event. In `ApplyRoundEffects`, a few ticks after enable (once the async starting credits have landed), double each player's balance via a dedicated `"Rich Round Bonus"` grant — which `OnBalanceChange` skips so it isn't also hit by the 3× gain multiplier. In-round 3× behaviour is unchanged.

Note: the `SPECIAL_ROUND_RICH` description still only mentions the starting bonus; it could be updated to also mention 3× in-round gains (separate locale tweak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
