### PR TITLE
fix: Body Paint persists through rounds (per-round uses not reset)

### DIFF
--- a/TTT/CS2/Items/BodyPaint/BodyPaintListener.cs
+++ b/TTT/CS2/Items/BodyPaint/BodyPaintListener.cs
@@ -3,11 +3,13 @@ using Microsoft.Extensions.DependencyInjection;
 using ShopAPI;
 using ShopAPI.Configs;
 using TTT.API.Events;
+using TTT.API.Game;
 using TTT.API.Player;
 using TTT.API.Storage;
 using TTT.CS2.API;
 using TTT.CS2.Extensions;
 using TTT.Game.Events.Body;
+using TTT.Game.Events.Game;
 using TTT.Game.Listeners;
 
 namespace TTT.CS2.Items.BodyPaint;
@@ -34,6 +36,17 @@ public class BodyPaintListener(IServiceProvider provider)
     if (ev.Identifier == null || !usePaint(ev.Identifier)) return;
     ev.IsCanceled = true;
     body.SetColor(config.ColorToApply);
+  }
+
+  // Body paint is a per-round purchase. The shop clears item ownership each
+  // round, but the remaining-uses cache below was never reset, so leftover uses
+  // carried into later rounds and let a now-Innocent/Detective keep painting
+  // bodies (and get killed as a "traitor"). Clear it on round end.
+  [UsedImplicitly]
+  [EventHandler]
+  public void OnRoundEnd(GameStateUpdateEvent ev) {
+    if (ev.NewState != State.FINISHED) return;
+    uses.Clear();
   }
 
   private bool usePaint(IPlayer player) {


### PR DESCRIPTION
## Bug: Body Paint persists through rounds

**Scope:** CS2 TTT

If you buy Body Paint (or roll it via RTD), the remaining uses **carry over to later rounds** until used up — so an **Innocent/Detective** can end up painting bodies (a Traitor item) and get killed for "having a Traitor item."

### Root cause
`BodyPaintListener` gates painting on `shop.HasItem<BodyPaintItem>` **only on the first paint** (when the player isn't yet in the `uses` dictionary). The shop clears item *ownership* each round (`RoundShopClearer.ClearItems`), but the `uses` dictionary is **never reset**, so once a player is in `uses` they keep painting on subsequent rounds, bypassing the (now-cleared) ownership check.

### Fix
Clear `uses` on round end (`GameStateUpdateEvent` → `State.FINISHED`), the same per-round-cleanup pattern Tripwire uses. Body paint is now properly scoped to the round it was bought in — must be re-purchased each round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
