### PR TITLE
fix: round-end link -> ttt.edgegamers.com (was ttt.localhost placeholder)

### DIFF
--- a/TTT/Stats/lang/en.yml
+++ b/TTT/Stats/lang/en.yml
@@ -1,2 +1,2 @@
 ﻿API_ROUND_START: "%PREFIX% Round {yellow}#{0} {grey}has started!"
-API_ROUND_END: "%PREFIX% Round end! Logs are available at {blue}http://ttt.localhost/round/{0}{grey}."
+API_ROUND_END: "%PREFIX% Round end! Logs are available at {blue}https://ttt.edgegamers.com/round/{0}{grey}."


### PR DESCRIPTION
The per-round post (`API_ROUND_END`) is sourced from `TTT/Stats/lang/en.yml` (the `lang/*.json` is generated + gitignored). The source hardcoded `http://ttt.localhost/round/{0}`; **prod still serves an older build with `ttt.edgegamers.io`**. No deploy-time substitution exists for it, so set the source to the live domain: `https://ttt.edgegamers.com/round/{0}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)