### PR TITLE
fix: only assign roles to alive players at round start

### DIFF
--- a/TTT/CS2/Game/CS2Game.cs
+++ b/TTT/CS2/Game/CS2Game.cs
@@ -82,8 +82,13 @@ public class CS2Game(IServiceProvider provider) : RoundBasedGame(provider) {
     var players = Utilities.GetPlayers()
      .Where(p => p is { Team: CsTeam.Terrorist or CsTeam.CounterTerrorist });
 
+    // Only players who are actually alive (spawned, Health > 0) count as round
+    // participants. A player who connects during the countdown has an async
+    // Respawn() scheduled; if StartRound fires before it completes they are on a
+    // team but still dead, and must not be assigned a role or recorded in stats.
     return players.Select(p => converter.GetPlayer(p))
      .OfType<IOnlinePlayer>()
+     .Where(p => p.IsAlive)
      .ToHashSet();
   }
 }


### PR DESCRIPTION
## Problem
A player connecting during the start countdown gets an **async** `Respawn()` scheduled in `LateSpawnListener`. If the countdown fires `StartRound()` before that respawn completes, the player is on a team but still **dead** (`Health == 0`). `CS2Game.GetParticipants()` filtered by **team only**, so that player was made a round participant — assigned a role (e.g. Innocent), added to `game.Players`, and recorded by the stats `RoundListener` — then moved to spectator ~30s later for being AFK, leaving a phantom innocent in the round data.

Reported in-game: *"joined just before the round started, it counted me but I was 'dead', so it defined me as an innocent, then moved me to spec after being AFK."*

## Fix
Filter `GetParticipants()` by `IsAlive` so only actually-spawned players (`Pawn.Value.Health > 0`) become participants. This is the single upstream gate feeding role assignment, `game.Players`, and the stats payload, so it fixes all the downstream symptoms at once. It's also consistent with the win-condition counting in `RoundBasedGame` (`RoundBasedGame.cs:144`), which already gates on `IsAlive`.

```diff
 return players.Select(p => converter.GetPlayer(p))
  .OfType<IOnlinePlayer>()
+ .Where(p => p.IsAlive)
  .ToHashSet();
```

## Notes
- One-line behavioral change; `IsAlive` is already on `IOnlinePlayer`.
- The round's minimum-players gate now counts only alive players (intended).
- Not unit-testable (relies on the live CS2 engine via `Utilities.GetPlayers()` + pawn health); verification is in-game.
- Could not build locally (only the net8 SDK is available here; project targets net10) — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)