### PR TITLE
fix: only assign roles to alive players at round start

### DIFF
--- a/TTT/CS2/Game/CS2Game.cs
+++ b/TTT/CS2/Game/CS2Game.cs
@@ -82,8 +82,13 @@ public class CS2Game(IServiceProvider provider) : RoundBasedGame(provider) {
     var players = Utilities.GetPlayers()
      .Where(p => p is { Team: CsTeam.Terrorist or CsTeam.CounterTerrorist });
 
+    // Only players who are actually alive (spawned, Health > 0) count as round
+    // participants. A player who connects during the countdown has an async
+    // Respawn() scheduled; if StartRound fires before it completes they are on a
+    // team but still dead, and must not be assigned a role or recorded in stats.
     return players.Select(p => converter.GetPlayer(p))
      .OfType<IOnlinePlayer>()
+     .Where(p => p.IsAlive)
      .ToHashSet();
   }
 }


### PR DESCRIPTION
Targets **dev** for testing on the dev TTT server (prod/main unchanged).

## Problem
A player connecting during the start countdown gets an async `Respawn()` scheduled in `LateSpawnListener`. If the countdown fires `StartRound()` before that respawn completes, the player is on a team but still dead (`Health == 0`). `CS2Game.GetParticipants()` filtered by **team only**, so that player became a round participant — assigned a role (e.g. Innocent), added to `game.Players`, and recorded by the stats `RoundListener` — then moved to spectator ~30s later for being AFK, leaving a phantom innocent in the round data.

## Fix
Filter `GetParticipants()` by `IsAlive` (`Pawn.Value.Health > 0`) so only actually-spawned players become participants. Single upstream gate covering role assignment, `game.Players`, and the stats payload; consistent with the `IsAlive` win-condition counting in `RoundBasedGame`.

```diff
 return players.Select(p => converter.GetPlayer(p))
  .OfType<IOnlinePlayer>()
+ .Where(p => p.IsAlive)
  .ToHashSet();
```

Same change as #30, retargeted to dev. Verification is in-game (relies on the live CS2 engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)