### PR TITLE
Release: exclude dead players from round participants (2.3.2)

### DIFF
--- a/TTT/CS2/Game/CS2Game.cs
+++ b/TTT/CS2/Game/CS2Game.cs
@@ -82,8 +82,13 @@ public class CS2Game(IServiceProvider provider) : RoundBasedGame(provider) {
     var players = Utilities.GetPlayers()
      .Where(p => p is { Team: CsTeam.Terrorist or CsTeam.CounterTerrorist });
 
+    // Only players who are actually alive (spawned, Health > 0) count as round
+    // participants. A player who connects during the countdown has an async
+    // Respawn() scheduled; if StartRound fires before it completes they are on a
+    // team but still dead, and must not be assigned a role or recorded in stats.
     return players.Select(p => converter.GetPlayer(p))
      .OfType<IOnlinePlayer>()
+     .Where(p => p.IsAlive)
      .ToHashSet();
   }
 }


### PR DESCRIPTION
Promotes the participant `IsAlive` fix (#31) from dev to main for a stable release.

Fixes the bug where a player who connected during the start countdown (dead/not-yet-spawned) was counted as a round participant, assigned a role, recorded in stats, then AFK-kicked to spectator. `CS2Game.GetParticipants()` now filters by `IsAlive`.

Verified on dev; CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)