### PR TITLE
debug: temporary crash instrumentation

### DIFF
--- a/TTT/Game/EventBus.cs
+++ b/TTT/Game/EventBus.cs
@@ -43,8 +43,22 @@ public class EventBus(IServiceProvider provider) : IEventBus, ITerrorModule {
       ?.IgnoreCanceled == true)
         continue;
 
-      method.Invoke(listener, [ev]);
+      // TEMP crash instrumentation: flushed breadcrumbs so the last line before a
+      // native crash names the handler; managed throws are caught + logged.
+      var crumb = $"{type.Name}->{listener.GetType().Name}.{method.Name}";
+      dbg("evt:before " + crumb);
+      try { method.Invoke(listener, [ev]); }
+      catch (Exception e) {
+        dbg("evt:ERROR " + crumb + " :: " + (e.InnerException ?? e));
+      }
+      dbg("evt:after " + crumb);
     }
+  }
+
+  // TEMP: flushed debug line to stdout (survives a native crash; remove after).
+  internal static void dbg(string m) {
+    Console.WriteLine("[TTT-DBG] " + m);
+    Console.Out.Flush();
   }
 
   public void Dispose() { handlers.Clear(); }

--- a/TTT/Plugin/TTT.cs
+++ b/TTT/Plugin/TTT.cs
@@ -16,6 +16,18 @@ public class TTT(IServiceProvider provider) : BasePlugin {
   public override void Load(bool hotReload) {
     Logger.LogInformation($"{ModuleName} {ModuleVersion} Starting... ");
 
+    // TEMP crash instrumentation: surface anything currently swallowed
+    // (process-terminating throws + unobserved async exceptions). Remove after.
+    AppDomain.CurrentDomain.UnhandledException += (_, e) => {
+      Console.WriteLine("[TTT-DBG] UNHANDLED " + e.ExceptionObject);
+      Console.Out.Flush();
+    };
+    System.Threading.Tasks.TaskScheduler.UnobservedTaskException += (_, e) => {
+      Console.WriteLine("[TTT-DBG] UNOBSERVED-TASK " + e.Exception);
+      Console.Out.Flush();
+      e.SetObserved();
+    };
+
     scope = provider.CreateScope();
     var modules = scope.ServiceProvider.GetServices<ITerrorModule>().ToList();
     Logger.LogInformation($"Found {modules.Count} base modules to load.");


### PR DESCRIPTION
Temporary breadcrumbs to locate the native crash on shop/credits interaction. Revert after diagnosis.