### PR TITLE
fix(body): build against CSSharp 1.0.371 — corpses vanish on death after CS2 update

### DIFF
--- a/TTT/CS2/GameHandlers/BodySpawner.cs
+++ b/TTT/CS2/GameHandlers/BodySpawner.cs
@@ -80,8 +80,7 @@ public class BodySpawner(IServiceProvider provider) : IPluginModule {
       throw new ArgumentException("Pawn AbsOrigin is null",
         nameof(playerController));
 
-    origin.Z      += 30;
-    ragdoll.Speed =  0;
+    origin.Z += 30;
 
     ragdoll.CBodyComponent!.SceneNode!.Owner!.Entity!.Flags =
       (uint)(ragdoll.CBodyComponent!.SceneNode!.Owner!.Entity!.Flags

--- a/TTT/Directory.Build.props
+++ b/TTT/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.369"/>
+    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.371"/>
     <PackageReference Include="System.Reactive" Version="6.0.1"/>
   </ItemGroup>
 


### PR DESCRIPTION
## Player-reported bug
After today's CS2 update, **bodies vanish the instant a player dies** on TTT, breaking body identification.

## Root cause (confirmed on prod)
The server's CounterStrikeSharp runtime was upgraded to **1.0.371** during the update firefight (Jul 10), which **removed `CBaseEntity.Speed`**. The plugin builds against **1.0.369** and calls `ragdoll.Speed = 0` in `BodySpawner.makeGameRagdoll`, so every death throws:

```
System.MissingMethodException: Method not found:
'Single ByRef CounterStrikeSharp.API.Core.CBaseEntity.get_Speed()'
   at TTT.CS2.GameHandlers.BodySpawner.makeGameRagdoll(...)
   at TTT.CS2.GameHandlers.BodySpawner.OnDeath(...) BodySpawner.cs:line 40
```

Ragdoll creation aborts mid-setup → no corpse. **140 occurrences** in the prod logs, all in that one path.

## Fix
- Bump `CounterStrikeSharp.API` 1.0.369 → 1.0.371 (`TTT/Directory.Build.props`)
- Remove `ragdoll.Speed = 0;` — the member no longer exists, and it's a no-op for a VPhysics ragdoll (already teleported with zero velocity)

## Testing
- [ ] CI builds green against 1.0.371 (couldn't compile locally — only .NET 8 SDK available; plugin targets net10)
- [ ] On dev TTT server: player dies → identifiable corpse spawns and persists

## Not in this PR (separate follow-ups)
- **Grenades broken:** `GrenadeDataHelper` `TypeInitializationException` — the `CHEGrenadeProjectile_CreateFunc` gamedata signature no longer resolves on the new build. Needs a gamedata sig update, not a version bump.
- **closequarters T-room doors won't open:** no plugin door logic and no related errors — likely map-specific or engine `func_door` breakage. Needs an in-game cross-map test.

> Prod redeploy reminder: `cs2-ttt` runs under the `/app` anon volume, so deploy with `--renew-anon-volumes` or the new dll won't apply.